### PR TITLE
Fix example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,16 +14,17 @@ Fetching local system edid
 const EdidReader = require('edid-reader');
 const edidReader = new EdidReader();
 edidReader.scan()
-  .then(() => {
+.then(() => {
+  console.log('==========================');
+  edidReader.monitors.forEach((monitor) => {
+    console.log(`Vendor : ${monitor.vendor}`);
+    console.log(`Model  : ${monitor.modelName}`);
+    console.log(`EISA   : ${monitor.eisaId}`);
+    console.log(`Code   : ${monitor.productCode}`);
+    console.log(`Serial : ${monitor.serialNumber}`);
     console.log('==========================');
-    edidScanner.monitors.forEach((monitor) => {
-      console.log(`EISA :   ${monitor.edid.eisaId}`);
-      console.log(`Code :   ${monitor.edid.productCode}`);
-      console.log(`Serial : ${monitor.edid.serialNumber}`);
-      console.log(`Model :  ${monitor.edid.modelName}`);
-      console.log('==========================');
-    });
   });
+});
 ```
 
 Build


### PR DESCRIPTION
When I tested the example code, I found:
* It was called edidReader, not edidScanner
* There was no edid object on the edidReader instance
* Add vendorName
* Move modelName to the top, after vendor

I have only tested this on Mac OS, but it seems to correspond with what's in the examples folder.