### PR TITLE
Fix scanning on Linux

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,9 +16,9 @@ const EdidParser = require('./edid-parser');
 class EdidReader {
 
   // Source: http://www.komeil.com/blog/fix-edid-monitor-no-signal-dvi#li-comment-845
-  static eisaIds = require(`../data/eisa.json`);
+  static eisaIds = require('../data/eisa.json');
   // Source: https://uefi.org/acpi_id_list
-  static pnpIds = require(`../data/pnp.json`);
+  static pnpIds = require('../data/pnp.json');
 
   constructor() {
     if (!_.includes(['linux', 'darwin'], os.platform())) {

--- a/src/index.js
+++ b/src/index.js
@@ -59,7 +59,7 @@ class EdidReader {
   // Linux fetch EDID
   getLinuxSystemEdids() {
     // /sys/devices/pci0000\:00/0000\:00\:02.0/drm/card0/card0-HDMI-A-1/edid
-    return glob('/sys/devices/pci*/0000:*/drm/card*/card*/edid')
+    return glob('/sys/devices/pci*/0000:*/*/drm/card*/card*/edid')
       .map((edidFileName) => fs.readFileAsync(edidFileName)
         .then(buffer => ({filename: edidFileName, edid: buffer.toString('hex')})))
       .filter(result => result.edid !== '');
@@ -77,7 +77,7 @@ class EdidReader {
   // Scan host for edids
   scan() {
     return this.getSystemEdids()
-      .map(this.formatEdid)
+      .map(EdidReader.formatEdid)
       .then((rawEdids) => {
         this.monitors = _.map(rawEdids, ({filename, edid}) => {
           console.log(edid);

--- a/src/index.js
+++ b/src/index.js
@@ -80,7 +80,7 @@ class EdidReader {
       .map(EdidReader.formatEdid)
       .then((rawEdids) => {
         this.monitors = _.map(rawEdids, ({filename, edid}) => {
-          console.log(edid);
+          // console.log(edid);
           const edidObj = EdidReader.parse(edid);
           edidObj.outputName = EdidReader.cardOutputMapper(filename);
           return edidObj;

--- a/src/index.js
+++ b/src/index.js
@@ -16,9 +16,9 @@ const EdidParser = require('./edid-parser');
 class EdidReader {
 
   // Source: http://www.komeil.com/blog/fix-edid-monitor-no-signal-dvi#li-comment-845
-  static eisaIds = require(`${__dirname}/../data/eisa.json`);
+  static eisaIds = require(`../data/eisa.json`);
   // Source: https://uefi.org/acpi_id_list
-  static pnpIds = require(`${__dirname}/../data/pnp.json`);
+  static pnpIds = require(`../data/pnp.json`);
 
   constructor() {
     if (!_.includes(['linux', 'darwin'], os.platform())) {


### PR DESCRIPTION
This PR fixes scanning not working on Linux (fixes #4), removes debug output and changes the json `require` calls to not use `__dirname`. `require` is always relative to the script's directory, so this isn't needed.

Background: I use this in an application that is bundled to an executable with [pkg](https://www.npmjs.com/package/pkg), which doesn't work for dynamic `require` calls.

PS: If someone needs this right now: `npm i -S @wertarbyte/edid-reader`